### PR TITLE
docs:routeファイルの可読性向上の為リライト　#305

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,64 +1,76 @@
 Rails.application.routes.draw do
-  # uranai_controller.rbのルーティング
-  get "uranai/index"
-  # getはHTTPリクエストの種類の一つで、データの取得を意味する。今回は/uranai/indexというURLに対してGETリクエストが送られると、UranaiControllerのindexアクションが呼び出される。
 
-  post "uranai/predict", to: "uranai#predict"
-  # ai_controller.rbのルーティング
-  # namespaceとはURLの前に共通のパスをつけるためのもの。今回は/api/ai/recommendというURLになる。
-  # getはHTTPリクエストの種類の一つで、データの取得を意味する。postはデータの送信を意味する。
-  namespace :api do
-    get "ai/recommend"
-  end
-  # ai_controller.rbのルーティング（POSTリクエスト用）
-  # postとはHTTPリクエストの種類の一つで、データの送信を意味する。今回は/api/ai/recommendというURLに対してPOSTリクエストが送られると、Api::AiControllerのrecommendアクションが呼び出される。
-  namespace :api do
-    post "ai/recommend"
-  end
-
-
-  # Devise
+  # ============================================================
+  # 🔐 認証系（Devise）
+  # ============================================================
   devise_for :users, controllers: {
     registrations: "users/registrations",
     omniauth_callbacks: "users/omniauth_callbacks"
   }
 
-  # ダッシュボード（ログイン後の拠点）
-  resource :dashboard, only: :show
-  resources :users, only: [ :show ]
-  # ゲーム管理
-  resources :games do
-    collection do # collectionはゲーム全体への操作
-      get :igdb_search # ゲーム情報をigdb APIで引っ張ってくる際に必要
-    end
-
-    member do # memberは特定のゲームに対する操作
-      get    :confirm_destroy  # 削除確認画面
-      delete :remove_cover_image  # カバー画像削除
-    end
-  end
-
-
-  # プライバシーポリシー、使い方、利用規約ページ
-  get "/terms", to: "pages#terms", as: :terms
-  get "/privacy_policy", to: "pages#privacy_policy", as: :privacy_policy
-  get "/how_to", to: "pages#how_to", as: :how_to
-
-  # ログイン済みユーザーの root
+  # ログイン済みユーザーのroot
   authenticated :user do
     root to: "dashboards#show", as: :authenticated_root
   end
 
-  # 未ログインユーザーの root
+  # 未ログインユーザーのroot
   devise_scope :user do
     root to: "devise/sessions#new"
   end
 
-  # Rails 標準
-  get "up" => "rails/health#show", as: :rails_health_check
-  get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
-  get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
-  # 共有画像の保存
+  # ============================================================
+  # 👤 ユーザー系
+  # ============================================================
+  resource  :dashboard, only: :show
+  resources :users,     only: :show
+
+
+  # ============================================================
+  # 🎮 ゲーム管理系
+  # ============================================================
+  resources :games do
+    collection do
+      get :igdb_search       # IGDBからゲーム情報を検索
+    end
+
+    member do
+      get    :confirm_destroy    # 削除確認画面
+      delete :remove_cover_image # カバー画像削除
+    end
+  end
+
+
+  # ============================================================
+  # 🔮 AI・占い系
+  # ============================================================
+  # 占いおばばの部屋
+  get  "uranai/index"
+  post "uranai/predict", to: "uranai#predict"
+
+  # AIレコメンド（FastAPI連携）
+  namespace :api do
+    get  "ai/recommend"
+    post "ai/recommend"
+  end
+
+  # 共有画像の保存（X投稿フロー）
   post "/share_images", to: "share_images#create"
+
+
+  # ============================================================
+  # 📄 静的ページ系
+  # ============================================================
+  get "/terms",          to: "pages#terms",          as: :terms
+  get "/privacy_policy", to: "pages#privacy_policy", as: :privacy_policy
+  get "/how_to",         to: "pages#how_to",         as: :how_to
+
+
+  # ============================================================
+  # ⚙️ Rails標準
+  # ============================================================
+  get "up"             => "rails/health#show",       as: :rails_health_check
+  get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
+  get "manifest"       => "rails/pwa#manifest",      as: :pwa_manifest
+
 end


### PR DESCRIPTION
## 概要

重複した記述を統一
ジャンル分けをしわかりやすくしました

## 変更内容

- route全体の体裁　ジャンルがバラバラなものを統一 

~~~
現状（分かれている）
namespace :api do
  get  "ai/recommend"
end
namespace :api do
  post "ai/recommend"
end

統一
namespace :api do
  get  "ai/recommend"
  post "ai/recommend"
end
~~~

## 動作確認

- [x] ローカルで確認済み
- [x] テスト追加済み

## 関連Issue

closes #305 
